### PR TITLE
Add config xml with IOC description

### DIFF
--- a/iocBoot/iocCHIPIR_Collimator/config.xml
+++ b/iocBoot/iocCHIPIR_Collimator/config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<ioc_config xmlns:xi="http://www.w3.org/2001/XInclude">
+<config_part>
+<ioc_desc>CHIPIR collimator</ioc_desc>
+<macros>
+<macro name="PORT" pattern="^COM[0-9]+$" description="Serial COM Port" />
+</macros>
+</config_part>
+</ioc_config>


### PR DESCRIPTION
### Description of work

Add missing config.xml containing IOC description

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2048

### Acceptance criteria

The IOC description is shown in the IOC dialog box/configuration editor in the GUI. Note that a `make iocstartups` will be required.
